### PR TITLE
ユーザーがカタカナを全角または半角に変換する

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,6 +15,7 @@ import {
 } from "@material-ui/core";
 import { ArrowDownward } from "@material-ui/icons";
 import { CopyToClipboard } from "react-copy-to-clipboard";
+import { toHalfKatakana, toFullKatakana } from "./katakana";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -176,11 +177,94 @@ const AlphabetConverter = (classes) => {
 };
 
 const KatakanaConverter = (classes) => {
+  const [textWidth, setTextWidth] = React.useState("half");
+  const [beforeText, setBeforeText] = React.useState("");
+  const [afterText, setAfterText] = React.useState("");
+  const fullPlaceholder = "アイウエオ";
+  const halfPlaceholder = "ｱｲｳｴｵ";
+  const [beforePlaceholder, setBeforePlaceholder] = React.useState(
+    fullPlaceholder
+  );
+  const [afterPlaceholder, setAfterPlaceholder] = React.useState(
+    halfPlaceholder
+  );
+
+  const handleTextWidth = (event) => {
+    const value = event.target.value;
+    setTextWidth(value);
+    setBeforePlaceholder(value === "half" ? fullPlaceholder : halfPlaceholder);
+    setAfterPlaceholder(value === "half" ? halfPlaceholder : fullPlaceholder);
+    setAfterText(
+      value === "half" ? toHalfKatakana(afterText) : toFullKatakana(afterText)
+    );
+  };
+
+  const handleChangeText = (event) => {
+    const value = event.target.value;
+    setBeforeText(value);
+    setAfterText(
+      textWidth === "half" ? toHalfKatakana(value) : toFullKatakana(value)
+    );
+  };
+
+  const handleClear = () => {
+    setBeforeText("");
+    setAfterText("");
+  };
+
   return (
     <div className={classes.root}>
       <Typography variant="h6" className={classes.title}>
         カタカナを変換する
       </Typography>
+      <FormControl
+        component="fieldset"
+        fullWidth
+        margin="normal"
+        className={classes.formControl}
+      >
+        <RadioGroup
+          row
+          aria-label="alphabetConverter"
+          name="alphabetConverter"
+          value={textWidth}
+          onChange={handleTextWidth}
+        >
+          <FormControlLabel value="half" control={<Radio />} label="半角" />
+          <FormControlLabel value="full" control={<Radio />} label="全角" />
+        </RadioGroup>
+        <TextareaAutosize
+          rowsMin={5}
+          placeholder={beforePlaceholder}
+          value={beforeText}
+          onChange={handleChangeText}
+        />
+        <ArrowDownwardIcon />
+        <TextareaAutosize
+          rowsMin={5}
+          placeholder={afterPlaceholder}
+          value={afterText}
+        />
+        <MyButton
+          variant="outlined"
+          size="medium"
+          margin="normal"
+          className={classes.margin}
+          onClick={handleClear}
+        >
+          クリア
+        </MyButton>
+        <CopyToClipboard text={afterText}>
+          <MyButton
+            variant="contained"
+            size="medium"
+            color="secondary"
+            className={classes.margin}
+          >
+            コピー
+          </MyButton>
+        </CopyToClipboard>
+      </FormControl>
     </div>
   );
 };

--- a/src/katakana.js
+++ b/src/katakana.js
@@ -1,0 +1,138 @@
+const katakana = [
+  { full: "ア", half: "ｱ" },
+  { full: "イ", half: "ｲ" },
+  { full: "ウ", half: "ｳ" },
+  { full: "エ", half: "ｴ" },
+  { full: "オ", half: "ｵ" },
+  { full: "カ", half: "ｶ" },
+  { full: "キ", half: "ｷ" },
+  { full: "ク", half: "ｸ" },
+  { full: "ケ", half: "ｹ" },
+  { full: "コ", half: "ｺ" },
+  { full: "サ", half: "ｻ" },
+  { full: "シ", half: "ｼ" },
+  { full: "ス", half: "ｽ" },
+  { full: "セ", half: "ｾ" },
+  { full: "ソ", half: "ｿ" },
+  { full: "タ", half: "ﾀ" },
+  { full: "チ", half: "ﾁ" },
+  { full: "ツ", half: "ﾂ" },
+  { full: "テ", half: "ﾃ" },
+  { full: "ト", half: "ﾄ" },
+  { full: "ナ", half: "ﾅ" },
+  { full: "ニ", half: "ﾆ" },
+  { full: "ヌ", half: "ﾇ" },
+  { full: "ネ", half: "ﾈ" },
+  { full: "ノ", half: "ﾉ" },
+  { full: "ハ", half: "ﾊ" },
+  { full: "ヒ", half: "ﾋ" },
+  { full: "フ", half: "ﾌ" },
+  { full: "ヘ", half: "ﾍ" },
+  { full: "ホ", half: "ﾎ" },
+  { full: "マ", half: "ﾏ" },
+  { full: "ミ", half: "ﾐ" },
+  { full: "ム", half: "ﾑ" },
+  { full: "メ", half: "ﾒ" },
+  { full: "モ", half: "ﾓ" },
+  { full: "ヤ", half: "ﾔ" },
+  { full: "ユ", half: "ﾕ" },
+  { full: "ヨ", half: "ﾖ" },
+  { full: "ラ", half: "ﾗ" },
+  { full: "リ", half: "ﾘ" },
+  { full: "ル", half: "ﾙ" },
+  { full: "レ", half: "ﾚ" },
+  { full: "ロ", half: "ﾛ" },
+  { full: "ワ", half: "ﾜ" },
+  { full: "ヲ", half: "ｦ" },
+  { full: "ン", half: "ﾝ" },
+  { full: "ァ", half: "ｧ" },
+  { full: "ィ", half: "ｨ" },
+  { full: "ゥ", half: "ｩ" },
+  { full: "ェ", half: "ｪ" },
+  { full: "ォ", half: "ｫ" },
+  { full: "ッ", half: "ｯ" },
+  { full: "ャ", half: "ｬ" },
+  { full: "ュ", half: "ｭ" },
+  { full: "ョ", half: "ｮ" },
+  { full: "ガ", half: "ｶﾞ" },
+  { full: "ギ", half: "ｷﾞ" },
+  { full: "グ", half: "ｸﾞ" },
+  { full: "ゲ", half: "ｹﾞ" },
+  { full: "ゴ", half: "ｺﾞ" },
+  { full: "ザ", half: "ｻﾞ" },
+  { full: "ジ", half: "ｼﾞ" },
+  { full: "ズ", half: "ｽﾞ" },
+  { full: "ゼ", half: "ｾﾞ" },
+  { full: "ゾ", half: "ｿﾞ" },
+  { full: "ダ", half: "ﾀﾞ" },
+  { full: "ヂ", half: "ﾁﾞ" },
+  { full: "ヅ", half: "ﾂﾞ" },
+  { full: "デ", half: "ﾃﾞ" },
+  { full: "ド", half: "ﾄﾞ" },
+  { full: "バ", half: "ﾊﾞ" },
+  { full: "ビ", half: "ﾋﾞ" },
+  { full: "ブ", half: "ﾌﾞ" },
+  { full: "ベ", half: "ﾍﾞ" },
+  { full: "ボ", half: "ﾎﾞ" },
+  { full: "パ", half: "ﾊﾟ" },
+  { full: "ピ", half: "ﾋﾟ" },
+  { full: "プ", half: "ﾌﾟ" },
+  { full: "ペ", half: "ﾍﾟ" },
+  { full: "ポ", half: "ﾎﾟ" },
+  { full: "ヴ", half: "ｳﾞ" },
+  { full: "ヷ", half: "ﾜﾞ" },
+  { full: "ヺ", half: "ｦﾞ" },
+  { full: "。", half: "｡" },
+  { full: "、", half: "､" },
+  { full: "ー", half: "ｰ" },
+  { full: "「", half: "｢" },
+  { full: "」", half: "｣" },
+  { full: "・", half: "･" },
+  { full: "゛", half: "ﾞ" },
+  { full: "゜", half: "ﾟ" },
+];
+
+export const findHalfKatakana = (full) => {
+  const result = katakana.find((k) => {
+    return k.full === full;
+  });
+  return result ? result.half : full;
+};
+
+export const findFullKatakana = (half) => {
+  const result = katakana.find((k) => {
+    return k.half === half;
+  });
+  return result ? result.full : half;
+};
+
+export const toKatakana = (text) => {
+  return text
+    .replace(/[ぁ-ゔ]/g, (s) => String.fromCharCode(s.charCodeAt(0) + 0x60))
+    .replace(/ﾞ/g, "゛")
+    .replace(/ﾟ/g, "゜")
+    .replace(/()ウ゛/g, "ヴ")
+    .replace(/(ワ゛)/g, "ヷ")
+    .replace(/(ヰ゛)/g, "ヸ")
+    .replace(/(ヱ゛)/g, "ヹ")
+    .replace(/(ヲ゛)/g, "ヺ")
+    .replace(/(ゝ゛)/g, "ヾ")
+    .replace(/ゝ/g, "ヽ")
+    .replace(/ゞ/g, "ヾ")
+    .replace(/ゕ/g, "ヵ")
+    .replace(/ゖ/g, "ヶ");
+};
+
+export const toHalfKatakana = (text) => {
+  return toKatakana(text)
+    .split("")
+    .map((t) => findHalfKatakana(t) || t)
+    .join("");
+};
+
+export const toFullKatakana = (text) => {
+  return toKatakana(text)
+    .split("")
+    .map((t) => findFullKatakana(t) || t)
+    .join("");
+};


### PR DESCRIPTION
#### 概要
ユーザーがカタカナを全角または半角に変換する

#### issue
Fixed #5

#### 対応内容
- App.jsのコンポーネント`KatakanaConverter`に実装する

#### タスク
- [x] Chromeで動作すること

#### その他
 - 特になし